### PR TITLE
Updating Groups and Channels Pictures

### DIFF
--- a/docs/api/chat.swagger.ts
+++ b/docs/api/chat.swagger.ts
@@ -917,3 +917,87 @@
  *                   type: string
  *                   example: no chat found with the provided id
  */
+
+/**
+ * @swagger
+ * /chats/picture/{chatId}:
+ *   patch:
+ *     summary: Update the chat's profile picture
+ *     description: Upload a new profile picture for a specific chat. Only authorized users who are members of the chat are allowed to update the picture.
+ *     tags:
+ *       - Chat
+ *     parameters:
+ *       - in: path
+ *         name: chatId
+ *         required: true
+ *         description: Unique identifier of the chat
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               file:
+ *                 type: string
+ *                 format: binary
+ *                 description: The image file to be uploaded
+ *     responses:
+ *       201:
+ *         description: Chat picture updated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: success
+ *                 message:
+ *                   type: string
+ *                   example: chat picture updated successfully
+ *                 data:
+ *                   type: object
+ *                   example: {}
+ *       400:
+ *         description: Bad request - Chat does not exist
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: fail
+ *                 message:
+ *                   type: string
+ *                   example: this chat does no longer exists
+ *       403:
+ *         description: Forbidden - User not allowed
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: fail
+ *                 message:
+ *                   type: string
+ *                   example: you are not a member of this chat, you are not allowed here
+ *       500:
+ *         description: Server error - File upload failed
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: error
+ *                 message:
+ *                   type: string
+ *                   example: An error occurred while uploading the story
+ */

--- a/src/controllers/chatController.ts
+++ b/src/controllers/chatController.ts
@@ -3,7 +3,11 @@ import Chat from '@base/models/chatModel';
 import Message from '@base/models/messageModel';
 import NormalChat from '@base/models/normalChatModel';
 import User from '@base/models/userModel';
-import { getChats, getLastMessage } from '@base/services/chatService';
+import {
+  deleteChatPictureFile,
+  getChats,
+  getLastMessage,
+} from '@base/services/chatService';
 import IUser from '@base/types/user';
 import catchAsync from '@base/utils/catchAsync';
 import { NextFunction, Request, Response } from 'express';
@@ -231,3 +235,25 @@ export const setPrivacy = catchAsync(
     });
   }
 );
+
+export const updateChatPicture = catchAsync(async (req: any, res: Response) => {
+  const { chatId } = req.params;
+
+  if (!req.file) {
+    throw new AppError('An error occured while uploading the story', 500);
+  }
+
+  await deleteChatPictureFile(chatId);
+
+  await GroupChannel.findByIdAndUpdate(
+    chatId,
+    { photo: req.file.filename },
+    { new: true, runValidators: true }
+  );
+
+  res.status(201).json({
+    status: 'success',
+    message: 'chat picture updated successfuly',
+    data: {},
+  });
+});

--- a/src/controllers/chatController.ts
+++ b/src/controllers/chatController.ts
@@ -247,7 +247,7 @@ export const updateChatPicture = catchAsync(async (req: any, res: Response) => {
 
   await GroupChannel.findByIdAndUpdate(
     chatId,
-    { photo: req.file.filename },
+    { picture: req.file.filename },
     { new: true, runValidators: true }
   );
 

--- a/src/models/groupChannelModel.ts
+++ b/src/models/groupChannelModel.ts
@@ -27,6 +27,10 @@ const groupChannelSchema = new mongoose.Schema<IGroupChannel>({
     type: Boolean,
     default: false,
   },
+  picture: {
+    type: String,
+    default: '',
+  },
 });
 
 const GroupChannel = Chat.discriminator('GroupChannel', groupChannelSchema);

--- a/src/routes/chatRoute.ts
+++ b/src/routes/chatRoute.ts
@@ -9,6 +9,7 @@ import {
   getDraft,
   getChat,
   setPrivacy,
+  updateChatPicture,
 } from '@base/controllers/chatController';
 import { protect } from '@base/middlewares/authMiddleware';
 import upload from '@base/config/fileUploads';
@@ -20,6 +21,12 @@ router.use(protect);
 router.get('/', getAllChats);
 router.get('/messages/:chatId', restrictTo(), getMessages);
 
+router.patch(
+  '/picture/:chatId',
+  restrictTo(),
+  upload.single('file'),
+  updateChatPicture
+);
 router.patch('/destruct/:chatId', restrictTo(), enableSelfDestructing);
 router.patch('/un-destruct/:chatId', restrictTo(), disableSelfDestructing);
 router.post('/media', upload.single('file'), postMediaFile);

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -3,6 +3,10 @@ import NormalChat from '@base/models/normalChatModel';
 import Message from '@base/models/messageModel';
 import { Socket } from 'socket.io';
 import User from '@base/models/userModel';
+import fs from 'fs/promises';
+import path from 'path';
+import AppError from '@base/errors/AppError';
+import GroupChannel from '@base/models/groupChannelModel';
 
 export const getLastMessage = async (chats: any) => {
   const lastMessages = await Promise.all(
@@ -53,5 +57,32 @@ export const enableDestruction = async (
       await Message.findByIdAndDelete(messageId);
       socket.to(chatId).emit('DESTRUCT_MESSAGE', messageId);
     }, chat.destructionDuration * 1000);
+  }
+};
+
+export const deleteChatPictureFile = async (
+  chatId: mongoose.Types.ObjectId | string
+) => {
+  const chat = await GroupChannel.findById(chatId);
+
+  if (!chat) {
+    throw new AppError('No Chat exists with this ID', 404);
+  }
+
+  const fileName = chat.picture;
+  if (!fileName || !fileName.trim()) return;
+
+  const filePath = path.join(process.cwd(), 'src/public/media/', fileName);
+
+  try {
+    // Check if the file exists
+    await fs.access(filePath);
+    // Delete the file if it exists
+    await fs.unlink(filePath);
+  } catch (err: any) {
+    // Ignore file not found errors (ENOENT)
+    if (err.code !== 'ENOENT') {
+      throw err; // Rethrow unexpected errors
+    }
   }
 };

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -3,10 +3,9 @@ import NormalChat from '@base/models/normalChatModel';
 import Message from '@base/models/messageModel';
 import { Socket } from 'socket.io';
 import User from '@base/models/userModel';
-import fs from 'fs/promises';
-import path from 'path';
 import AppError from '@base/errors/AppError';
 import GroupChannel from '@base/models/groupChannelModel';
+import deleteFile from '@base/utils/deleteFile';
 
 export const getLastMessage = async (chats: any) => {
   const lastMessages = await Promise.all(
@@ -70,19 +69,5 @@ export const deleteChatPictureFile = async (
   }
 
   const fileName = chat.picture;
-  if (!fileName || !fileName.trim()) return;
-
-  const filePath = path.join(process.cwd(), 'src/public/media/', fileName);
-
-  try {
-    // Check if the file exists
-    await fs.access(filePath);
-    // Delete the file if it exists
-    await fs.unlink(filePath);
-  } catch (err: any) {
-    // Ignore file not found errors (ENOENT)
-    if (err.code !== 'ENOENT') {
-      throw err; // Rethrow unexpected errors
-    }
-  }
+  await deleteFile(fileName);
 };

--- a/src/services/storyService.ts
+++ b/src/services/storyService.ts
@@ -2,7 +2,7 @@ import AppError from '@base/errors/AppError';
 import Story from '@base/models/storyModel';
 import User from '@base/models/userModel';
 import mongoose from 'mongoose';
-import { unlink } from 'fs/promises';
+import fs from 'fs/promises';
 import path from 'path';
 import Chat from '@base/models/chatModel';
 import IStory from '@base/types/story';
@@ -41,8 +41,21 @@ export const deleteStoryFile = async (storyId: mongoose.Types.ObjectId) => {
   }
 
   const fileName = story.content;
+  if (!fileName || !fileName.trim()) return;
 
-  await unlink(path.join(process.cwd(), 'src/public/media/', fileName));
+  const filePath = path.join(process.cwd(), 'src/public/media/', fileName);
+
+  try {
+    // Check if the file exists
+    await fs.access(filePath);
+    // Delete the file if it exists
+    await fs.unlink(filePath);
+  } catch (err: any) {
+    // Ignore file not found errors (ENOENT)
+    if (err.code !== 'ENOENT') {
+      throw err; // Rethrow unexpected errors
+    }
+  }
 };
 
 // Returns all the users ids that the user has a private chat with

--- a/src/services/storyService.ts
+++ b/src/services/storyService.ts
@@ -2,8 +2,7 @@ import AppError from '@base/errors/AppError';
 import Story from '@base/models/storyModel';
 import User from '@base/models/userModel';
 import mongoose from 'mongoose';
-import fs from 'fs/promises';
-import path from 'path';
+import deleteFile from '@base/utils/deleteFile';
 import Chat from '@base/models/chatModel';
 import IStory from '@base/types/story';
 
@@ -41,21 +40,7 @@ export const deleteStoryFile = async (storyId: mongoose.Types.ObjectId) => {
   }
 
   const fileName = story.content;
-  if (!fileName || !fileName.trim()) return;
-
-  const filePath = path.join(process.cwd(), 'src/public/media/', fileName);
-
-  try {
-    // Check if the file exists
-    await fs.access(filePath);
-    // Delete the file if it exists
-    await fs.unlink(filePath);
-  } catch (err: any) {
-    // Ignore file not found errors (ENOENT)
-    if (err.code !== 'ENOENT') {
-      throw err; // Rethrow unexpected errors
-    }
-  }
+  await deleteFile(fileName);
 };
 
 // Returns all the users ids that the user has a private chat with

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,8 +1,7 @@
 import AppError from '@base/errors/AppError';
 import User from '@base/models/userModel';
-import fs from 'fs/promises';
+import deleteFile from '@base/utils/deleteFile';
 import mongoose from 'mongoose';
-import path from 'path';
 
 const deletePictureFile = async (userId: mongoose.Types.ObjectId | string) => {
   const user = await User.findById(userId);
@@ -12,20 +11,6 @@ const deletePictureFile = async (userId: mongoose.Types.ObjectId | string) => {
   }
 
   const fileName = user.photo;
-  if (!fileName || !fileName.trim()) return;
-
-  const filePath = path.join(process.cwd(), 'src/public/media/', fileName);
-
-  try {
-    // Check if the file exists
-    await fs.access(filePath);
-    // Delete the file if it exists
-    await fs.unlink(filePath);
-  } catch (err: any) {
-    // Ignore file not found errors (ENOENT)
-    if (err.code !== 'ENOENT') {
-      throw err; // Rethrow unexpected errors
-    }
-  }
+  await deleteFile(fileName);
 };
 export default deletePictureFile;

--- a/src/types/groupChannel.ts
+++ b/src/types/groupChannel.ts
@@ -7,6 +7,7 @@ interface IGroupChannel extends IChat {
   privacy: boolean;
   createdAt: Date;
   isFilterd: boolean;
+  picture: string;
 }
 
 export default IGroupChannel;

--- a/src/utils/deleteFile.ts
+++ b/src/utils/deleteFile.ts
@@ -1,0 +1,22 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+const deleteFile = async (fileName: string | undefined) => {
+  if (!fileName || !fileName.trim()) return;
+
+  const filePath = path.join(process.cwd(), 'src/public/media/', fileName);
+
+  try {
+    // Check if the file exists
+    await fs.access(filePath);
+    // Delete the file if it exists
+    await fs.unlink(filePath);
+  } catch (err: any) {
+    // Ignore file not found errors (ENOENT)
+    if (err.code !== 'ENOENT') {
+      throw err; // Rethrow unexpected errors
+    }
+  }
+};
+
+export default deleteFile;


### PR DESCRIPTION
- Fixed a small error that occurred when trying to delete a nonexistent story file.
- Added an attribute (picture) in group/channel chat model.
- Implement an endpoint (/chats/picture/:chatId) to update groups/channels picture.
- Add swagger doc for the created endpoint.
- refactor deleting a file process in User, Story and Chats.